### PR TITLE
fix smp hair crash

### DIFF
--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -17,7 +17,8 @@ void Graphics::detail::toggle_partition(RE::BSGeometry& a_shape, const RE::TESOb
 					slot -= 100;
 				}
 			}
-			if (a_arma.HasPartOf(slotMap.at(slot))) {
+			const auto bipedSlot = slotMap.find(slot);
+			if (bipedSlot != slotMap.end() && a_arma.HasPartOf(bipedSlot->second)) {
 				dismemberInstance->UpdateDismemberPartion(data.slot, a_hide);
 			}
 		}


### PR DESCRIPTION
As some users reported on nexus, EquipmentToggle would crash when using with a smp hair mod.
I attached a crash log which can easly reproduce on my PC.
[crash-2022-08-19-08-25-53.log](https://github.com/powerof3/EquipmentToggle/files/9380595/crash-2022-08-19-08-25-53.log)

This little change will fix the issue.